### PR TITLE
✨ feat: DataInitializer 생성 및 통합 초기화 로직 구현

### DIFF
--- a/backend/src/main/java/com/example/capstonedesign/application/ingest/DataInitializer.java
+++ b/backend/src/main/java/com/example/capstonedesign/application/ingest/DataInitializer.java
@@ -1,0 +1,68 @@
+package com.example.capstonedesign.application.ingest;
+
+import com.example.capstonedesign.application.ingest.Finance.FinlifeIngestService;
+import com.example.capstonedesign.application.ingest.LH.LhLeaseNoticeService;
+import com.example.capstonedesign.application.ingest.SH.ShIngestService;
+import com.example.capstonedesign.application.ingest.Youth.YouthPolicyIngestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    // 서비스별 데이터 수집 서비스 주입
+    private final FinlifeIngestService finlifeIngestService;         // 금융상품
+    private final LhLeaseNoticeService lhIngestService;              // LH 주거공고
+    private final ShIngestService shIngestService;                   // SH 주거공고
+    private final YouthPolicyIngestService youthPolicyIngestService; // 청년정책
+
+    /**
+     * 애플리케이션 실행 후 외부 API 데이터를 초기 동기화하는 메서드
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initData() {
+        log.info("🔹 [INIT] 서버 시작 - 초기 데이터 동기화 시작");
+
+        try {
+            log.info("🏦 금융상품 동기화 시작");
+            finlifeIngestService.syncCompanies(3);
+            finlifeIngestService.syncDepositAndSaving(3);
+            finlifeIngestService.syncLoans(3);
+            log.info("✅ 금융상품 동기화 완료");
+        } catch (Exception e) {
+            log.error("❌ 금융 동기화 실패", e);
+        }
+
+        try {
+            log.info("🏠 LH 주거공고 동기화 시작");
+            lhIngestService.syncNotices();
+            log.info("✅ LH 동기화 완료");
+        } catch (Exception e) {
+            log.error("❌ LH 동기화 실패", e);
+        }
+
+        try {
+            log.info("🏢 SH 주거공고 동기화 시작");
+            shIngestService.syncNotices();
+            log.info("✅ SH 동기화 완료");
+        } catch (Exception e) {
+            log.error("❌ SH 동기화 실패", e);
+        }
+
+        try {
+            log.info("💡 청년정책 동기화 시작");
+            youthPolicyIngestService.syncPolicies();
+            log.info("✅ 청년정책 동기화 완료");
+        } catch (Exception e) {
+            log.error("❌ 청년정책 동기화 실패", e);
+        }
+
+        log.info("🎉 [INIT COMPLETE] 모든 초기 데이터 동기화 완료!");
+    }
+}
+

--- a/backend/src/main/java/com/example/capstonedesign/application/ingest/LH/LhLeaseNoticeService.java
+++ b/backend/src/main/java/com/example/capstonedesign/application/ingest/LH/LhLeaseNoticeService.java
@@ -144,4 +144,9 @@ public class LhLeaseNoticeService {
             log.error("❌ LH 공고 수집 실패: {}", e.getMessage(), e);
         }
     }
+
+    /** 프로젝트 전체 구조 통일용 Wrapper 메서드 */
+    public void syncNotices() {
+        fetchNotices();
+    }
 }

--- a/backend/src/main/java/com/example/capstonedesign/application/ingest/SH/ShIngestService.java
+++ b/backend/src/main/java/com/example/capstonedesign/application/ingest/SH/ShIngestService.java
@@ -211,4 +211,9 @@ public class ShIngestService {
     private String toJson(Object obj) {
         try { return MAPPER.writeValueAsString(obj); } catch (Exception e) { return "[]"; }
     }
+
+    /** 프로젝트 전체 구조 통일용 Wrapper 메서드 */
+    public void syncNotices() {
+        crawlAll(); // 내부 기존 메서드 실행
+    }
 }

--- a/backend/src/main/java/com/example/capstonedesign/application/ingest/Youth/YouthPolicyIngestService.java
+++ b/backend/src/main/java/com/example/capstonedesign/application/ingest/Youth/YouthPolicyIngestService.java
@@ -78,4 +78,9 @@ public class YouthPolicyIngestService {
             page++;
         }
     }
+
+    /** 프로젝트 전체 일관성을 위한 Wrapper */
+    public void syncPolicies() {
+        ingestAllPolicies();  // 기존 메서드 호출
+    }
 }

--- a/backend/src/main/java/com/example/capstonedesign/domain/youthpolicies/dto/response/YouthPolicyApiResponse.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/youthpolicies/dto/response/YouthPolicyApiResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -68,5 +69,19 @@ public class YouthPolicyApiResponse {
         private String plcySprtCn;        // 지원 내용
         private String bizPrdBgngYmd;     // 사업 시작일
         private String bizPrdEndYmd;      // 사업 종료일
+    }
+
+    /** 빈 응답용 정적 메서드 */
+    public static YouthPolicyApiResponse empty() {
+        YouthPolicyApiResponse resp = new YouthPolicyApiResponse();
+
+        resp.setResultCode(0);  // 기본값: 0 (정상), 혹은 -1로 지정 가능
+        resp.setResultMessage("NO_DATA");
+
+        Result result = new Result();
+        result.setYouthPolicyList(Collections.emptyList());
+        resp.setResult(result);
+
+        return resp;
     }
 }

--- a/backend/src/main/java/com/example/capstonedesign/infra/youth/YouthPolicyClient.java
+++ b/backend/src/main/java/com/example/capstonedesign/infra/youth/YouthPolicyClient.java
@@ -2,17 +2,21 @@ package com.example.capstonedesign.infra.youth;
 
 import com.example.capstonedesign.domain.youthpolicies.dto.response.YouthPolicyApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * YouthPolicyClient
  * -------------------------------------------------
- * - 온통청년(Youth Center) 정책 API 클라이언트
- * - 정책 목록 조회 (키워드, 지역코드, 페이지 단위)
+ * 온통청년(Youth Center) 정책 API를 호출하여 정책 데이터를 조회하는 클라이언트
+ * - 키워드, 지역 코드, 페이지 정보를 기반으로 정책 목록을 요청
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class YouthPolicyClient {
@@ -44,6 +48,39 @@ public class YouthPolicyClient {
                 .build()
                 .toUriString();
 
-        return restTemplate.getForObject(url, YouthPolicyApiResponse.class);
+        try {
+            // 1. JSON 요청 헤더 명시
+            HttpHeaders headers = new HttpHeaders();
+            headers.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            // 2. exchange로 요청 (getForObject보다 안전)
+            ResponseEntity<YouthPolicyApiResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    YouthPolicyApiResponse.class
+            );
+
+            // 3. 정상 응답 반환
+            return response.getBody();
+
+        } catch (HttpServerErrorException e) {
+            // 4. 서버 내부 오류 (HTML 반환 포함)
+            String body = e.getResponseBodyAsString();
+            if (body != null && body.contains("<html")) {
+                log.error("❌ 온통청년 서버에서 HTML 에러 페이지 반환됨 (점검 중 가능성 높음)");
+            } else {
+                log.error("❌ 온통청년 서버 오류 발생: {}", e.getMessage());
+            }
+            // 앱 종료 방지 → 빈 응답으로 대체
+            return YouthPolicyApiResponse.empty();
+
+        } catch (Exception e) {
+            // 5. 기타 예외 (연결 실패, 파싱 실패 등)
+            log.error("⚠️ 청년정책 API 호출 중 예외 발생: {}", e.getMessage());
+            return YouthPolicyApiResponse.empty();
+        }
     }
 }

--- a/backend/src/main/resources/youth.sql
+++ b/backend/src/main/resources/youth.sql
@@ -21,8 +21,8 @@ CREATE TABLE users
     created_at           TIMESTAMP                    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at           TIMESTAMP                    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     notification_enabled BOOLEAN                      NOT NULL DEFAULT TRUE,
-    notification_channel ENUM ('EMAIL','KAKAO','SMS') NOT NULL DEFAULT 'EMAIL'
-    birthdate DATE NOT NULL;
+    notification_channel ENUM ('EMAIL','KAKAO','SMS') NOT NULL DEFAULT 'EMAIL',
+    birthdate            DATE                         NOT NULL
 );
 
 -- =========================
@@ -198,7 +198,7 @@ CREATE TABLE youth_policies
     category_middle VARCHAR(100),
     agency          VARCHAR(255),
     apply_url       VARCHAR(500),
-    region_code     TEXT,
+    region_code     LONGTEXT,
     target_age      VARCHAR(50),
     support_content MEDIUMTEXT,
     start_date      VARCHAR(100),


### PR DESCRIPTION
- LH, SH, 금융, Youth의 IngestService를 하나의 초기화 프로세스로 통합 실행하도록 구조 변경
- 외부 API 통신 장애 발생 시 서비스 중단을 방지하기 위한 try-catch 및 경고 로그 추가
- YouthPolicyClient에 HttpServerErrorException 대응 로직 추가로 HTML 응답 시 안정적으로 무시 처리
- YouthPolicyApiResponse에 empty() 메서드 추가하여 API 장애 시 NPE 방지 및 안전한 기본 응답 제공
- region_code 컬럼의 길이 제한 문제 해결을 위해 LONGTEXT 타입으로 확장
- Unknown database 'youth' 오류 해결을 위해 CREATE SCHEMA IF NOT EXISTS 구문 추가
- DataInitializer 실행 순서를 조정하고 로그 포맷을 통일하여 가독성 개선