### PR TITLE
✨ feat: DB 기반 Y-Nest 챗봇 '네스티' 백엔드·프론트 구현

### DIFF
--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/controller/ChatController.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/controller/ChatController.java
@@ -1,0 +1,33 @@
+package com.example.capstonedesign.domain.chatbot.controller;
+
+import com.example.capstonedesign.domain.chatbot.dto.request.ChatRequestDto;
+import com.example.capstonedesign.domain.chatbot.dto.response.ChatResponseDto;
+import com.example.capstonedesign.domain.chatbot.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Chat", description = "DB 기반 Y-Nest 검색 챗봇 API")
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @Operation(
+            summary = "챗봇과 대화 (DB 기반)",
+            description = "사용자 메시지를 전달하면, Y-Nest DB를 검색해서 간단한 안내를 반환합니다."
+    )
+    @PostMapping
+    public ResponseEntity<ChatResponseDto> chat(@Valid @RequestBody ChatRequestDto requestDto) {
+        ChatResponseDto responseDto = chatService.chat(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/dto/request/ChatRequestDto.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/dto/request/ChatRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.capstonedesign.domain.chatbot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRequestDto {
+
+    @NotBlank(message = "message는 비어 있을 수 없습니다.")
+    private String message;
+}
+

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/dto/response/ChatResponseDto.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/dto/response/ChatResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.capstonedesign.domain.chatbot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatResponseDto {
+
+    private String reply;
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/ChatMessage.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/ChatMessage.java
@@ -1,0 +1,37 @@
+package com.example.capstonedesign.domain.chatbot.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatSender sender;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onPersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/ChatSender.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/ChatSender.java
@@ -1,0 +1,6 @@
+package com.example.capstonedesign.domain.chatbot.entity;
+
+public enum ChatSender {
+    USER,
+    BOT
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/IntentType.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/entity/IntentType.java
@@ -1,0 +1,10 @@
+package com.example.capstonedesign.domain.chatbot.entity;
+
+public enum IntentType {
+    HOUSING,
+    FINANCE,
+    POLICY,
+    HELP,
+    UNKNOWN
+}
+

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package com.example.capstonedesign.domain.chatbot.repository;
+
+import com.example.capstonedesign.domain.chatbot.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Integer> {
+
+    Page<ChatMessage> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/ChatService.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/ChatService.java
@@ -1,0 +1,10 @@
+package com.example.capstonedesign.domain.chatbot.service;
+
+import com.example.capstonedesign.domain.chatbot.dto.request.ChatRequestDto;
+import com.example.capstonedesign.domain.chatbot.dto.response.ChatResponseDto;
+
+public interface ChatService {
+
+    ChatResponseDto chat(ChatRequestDto requestDto);
+}
+

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/ChatServiceImpl.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/ChatServiceImpl.java
@@ -1,0 +1,248 @@
+package com.example.capstonedesign.domain.chatbot.service;
+
+import com.example.capstonedesign.domain.chatbot.dto.request.ChatRequestDto;
+import com.example.capstonedesign.domain.chatbot.dto.response.ChatResponseDto;
+import com.example.capstonedesign.domain.chatbot.entity.ChatMessage;
+import com.example.capstonedesign.domain.chatbot.entity.ChatSender;
+import com.example.capstonedesign.domain.chatbot.entity.IntentType;
+import com.example.capstonedesign.domain.chatbot.repository.ChatMessageRepository;
+import com.example.capstonedesign.domain.chatbot.service.DB.DbChatSearchService;
+import com.example.capstonedesign.domain.chatbot.service.DB.DbIntentDetector;
+import com.example.capstonedesign.domain.housingannouncements.entity.LhNotice;
+import com.example.capstonedesign.domain.products.entity.Products;
+import com.example.capstonedesign.domain.shannouncements.entity.ShAnnouncement;
+import com.example.capstonedesign.domain.youthpolicies.entity.YouthPolicy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final DbIntentDetector dbIntentDetector;
+    private final SimpleTextExtractor textExtractor;
+    private final DbChatSearchService dbChatSearchService;
+
+    @Override
+    @Transactional
+    public ChatResponseDto chat(ChatRequestDto requestDto) {
+        String userMessage = requestDto.getMessage().trim();
+
+        // 1) 사용자 메시지 로그 저장
+        ChatMessage userChat = ChatMessage.builder()
+                .sender(ChatSender.USER)
+                .content(userMessage)
+                .build();
+        chatMessageRepository.save(userChat);
+
+        // 2) Intent 판별
+        IntentType intent = dbIntentDetector.detectIntent(userMessage);
+        log.info("Detected intent: {}", intent);
+
+        // 3) Intent별 처리
+        String replyText = switch (intent) {
+            case HOUSING -> handleHousingQuery(userMessage);
+            case FINANCE -> handleFinanceQuery(userMessage);
+            case POLICY  -> handlePolicyQuery(userMessage);
+            case HELP    -> buildHelpMessage();
+            case UNKNOWN -> buildUnknownMessage();
+        };
+
+        // 4) 봇 메시지 로그 저장
+        ChatMessage botChat = ChatMessage.builder()
+                .sender(ChatSender.BOT)
+                .content(replyText)
+                .build();
+        chatMessageRepository.save(botChat);
+
+        // 5) 응답 반환
+        return ChatResponseDto.builder()
+                .reply(replyText)
+                .build();
+    }
+
+    // ====== Intent별 로직 ======
+
+    private String handleHousingQuery(String userMessage) {
+        String region = textExtractor.extractRegion(userMessage);          // 서울/경기/...
+        String keyword = textExtractor.extractHousingKeyword(userMessage); // 전세/월세/... 또는 ""
+
+        String lower = userMessage.toLowerCase();
+        boolean preferLh = lower.contains("lh") || userMessage.contains("엘에이치") ;
+        boolean preferSh = lower.contains("sh") || userMessage.contains("에스에이치");
+
+        List<LhNotice> lhList = dbChatSearchService
+                .findTopLhByRegionAndKeyword(region, keyword, 5);
+        List<ShAnnouncement> shList = dbChatSearchService
+                .findTopShByRegionAndKeyword(region, keyword, 5);
+
+        // 1) LH 우선 요청인 경우
+        if (preferLh) {
+            if (!lhList.isEmpty()) {
+                return buildHousingReply(region, keyword, lhList, List.of());
+            } else if (!shList.isEmpty()) {
+                return "요청하신 LH 공고는 현재 검색되지 않았어요. 🥺\n" +
+                        "대신 비슷한 SH 공고를 몇 가지 보여 드릴게요.\n\n"
+                        + buildHousingReply(region, keyword, List.of(), shList);
+            } else {
+                return buildHousingEmptyReply(region, keyword);
+            }
+        }
+
+        // 2) SH 우선 요청인 경우
+        if (preferSh) {
+            if (!shList.isEmpty()) {
+                return buildHousingReply(region, keyword, List.of(), shList);
+            } else if (!lhList.isEmpty()) {
+                return "요청하신 SH 공고는 현재 검색되지 않았어요. 🥺\n" +
+                        "대신 비슷한 LH 공고를 몇 가지 보여 드릴게요.\n\n"
+                        + buildHousingReply(region, keyword, lhList, List.of());
+            } else {
+                return buildHousingEmptyReply(region, keyword);
+            }
+        }
+
+        // 3) 기관 언급이 없으면 기존처럼 둘 다 섞어서
+        if (lhList.isEmpty() && shList.isEmpty()) {
+            return buildHousingEmptyReply(region, keyword);
+        }
+
+        return buildHousingReply(region, keyword, lhList, shList);
+    }
+
+    private String buildHousingReply(
+            String region,
+            String keyword,
+            List<LhNotice> lhList,
+            List<ShAnnouncement> shList
+    ) {
+        String displayRegion = (region == null || region.isBlank()) ? "전체" : region;
+        boolean hasKeyword = !(keyword == null || keyword.isBlank());
+
+        StringBuilder sb = new StringBuilder();
+        if (hasKeyword) {
+            sb.append(String.format(
+                    "%s 지역에서 '%s' 관련 주거 공고를 몇 가지 찾아봤어요. 😆\n\n",
+                    displayRegion, keyword
+            ));
+        } else {
+            // 키워드 없으면: 지역 전체 공고 안내
+            sb.append(String.format(
+                    "%s 지역 주거 공고를 몇 가지 가져와 봤어요. 😆\n\n",
+                    displayRegion
+            ));
+        }
+
+        lhList.forEach(n -> sb.append("- [LH] ")
+                .append(n.getPanNm())
+                .append(" (게시: ").append(n.getPanNtStDt()).append(")\n"));
+
+        shList.forEach(n -> sb.append("- [SH] ")
+                .append(n.getTitle())
+                .append(" (게시: ").append(n.getPostDate()).append(")\n"));
+
+        sb.append("\n자세한 내용은 주거 페이지에서 해당 공고 카드를 눌러 확인해 주세요!");
+
+        return sb.toString();
+    }
+
+    private String buildHousingEmptyReply(String region, String keyword) {
+        String displayRegion = (region == null || region.isBlank()) ? "전체" : region;
+        String displayKeyword = (keyword == null || keyword.isBlank()) ? "전체" : keyword;
+
+        return String.format(
+                "%s 지역에서 '%s' 관련 주거 공고를 찾지 못했어요. 😢\n" +
+                        "지역이나 키워드를 조금 더 넓게 바꿔서 다시 물어봐 주세요!",
+                displayRegion, displayKeyword
+        );
+    }
+
+
+    private String handleFinanceQuery(String userMessage) {
+        String keyword = textExtractor.extractFinanceKeyword(userMessage);
+        List<Products> list = dbChatSearchService
+                .findTopFinanceByKeyword(keyword, 5);
+
+        if (list.isEmpty()) {
+            return String.format(
+                    "'%s' 관련 금융 상품을 찾지 못했어요. 😢\n" +
+                            "조금 더 일반적인 키워드(예: 청년, 적금, 예금, 대출)로 다시 물어봐 주세요!",
+                    keyword.isBlank() ? "전체" : keyword
+            );
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format(
+                "'%s' 관련 금융 상품 몇 가지를 가져와 봤어요. 😆\n\n",
+                keyword.isBlank() ? "전체" : keyword
+        ));
+
+        list.forEach(p -> sb.append("- ")
+                .append(p.getName())
+                .append(" / ").append(p.getProvider())
+                .append("\n"));
+
+        sb.append("\n금융 > 상품 페이지에서 각 상품을 눌러 금리/조건을 자세히 확인해 주세요!");
+
+        return sb.toString();
+    }
+
+    private String handlePolicyQuery(String userMessage) {
+        // 1) 정책용 키워드 추출
+        String keyword = textExtractor.extractPolicyKeyword(userMessage);
+
+        // 2) 1차 검색
+        List<YouthPolicy> list = dbChatSearchService
+                .findTopPolicyByKeyword(keyword, 5);
+
+        // 3) 1차 검색 실패 시, 기본 키워드로 한 번 더 (fallback)
+        if (list.isEmpty() && !"청년".equals(keyword)) {
+            list = dbChatSearchService.findTopPolicyByKeyword("청년", 5);
+        }
+
+        if (list.isEmpty()) {
+            return "청년 정책 검색 결과가 없어요. 😢\n" +
+                    "조금 더 짧은 키워드(예: 전세, 월세, 취업, 창업, 교통 등)로 다시 물어봐 주세요!";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("청년 정책 관련해서 이런 것들을 찾아봤어요. 😆\n\n");
+
+        list.forEach(p -> sb.append("- ")
+                .append(p.getPolicyName())
+                .append(" / ").append(p.getDescription())
+                .append("\n"));
+
+        sb.append("\n정책 페이지에서 관심 있는 정책을 눌러 상세 내용을 확인해 주세요!");
+
+        return sb.toString();
+    }
+
+    private String buildHelpMessage() {
+        return """
+                저는 Y-Nest 챗봇, 네스티예요. 🪽
+                
+                - "서울 전세 지원 뭐 있어?" 처럼 지역 + 전세/월세 키워드로 물어보시면 주거 공고를 찾아 드려요.
+                - "청년 적금 추천해 줘" 처럼 금융 상품 키워드를 질문하시면 관련 상품을 보여 드려요.
+                - "청년 정책 알려 줘" 처럼 정책 관련 키워드를 말해 주시면 관련 정책을 찾아드려요.
+
+                화면의 주거/금융/정책 탭과 함께 사용하면 더 편하게 혜택을 찾을 수 있어요!
+                """;
+    }
+
+    private String buildUnknownMessage() {
+        return """
+                아직 제가 이해하기 어려운 질문이에요. 🥺
+                - 주거(전세/월세/청년주택)
+                - 금융(예금/적금/대출)
+                - 청년 정책(지원금/사업/보조금)
+                관련해서 다시 한번 물어봐 주시면, 가능한 범위에서 찾아볼게요!
+                """;
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/DB/DbChatSearchService.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/DB/DbChatSearchService.java
@@ -1,0 +1,84 @@
+package com.example.capstonedesign.domain.chatbot.service.DB;
+
+import com.example.capstonedesign.domain.housingannouncements.entity.LhNotice;
+import com.example.capstonedesign.domain.housingannouncements.repository.LhNoticeRepository;
+import com.example.capstonedesign.domain.products.entity.ProductType;
+import com.example.capstonedesign.domain.products.entity.Products;
+import com.example.capstonedesign.domain.products.repository.ProductsRepository;
+import com.example.capstonedesign.domain.shannouncements.entity.ShAnnouncement;
+import com.example.capstonedesign.domain.shannouncements.repository.ShAnnouncementRepository;
+import com.example.capstonedesign.domain.youthpolicies.entity.YouthPolicy;
+import com.example.capstonedesign.domain.youthpolicies.repository.YouthPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DbChatSearchService {
+
+    private final LhNoticeRepository lhNoticeRepository;
+    private final ShAnnouncementRepository shAnnouncementRepository;
+    private final YouthPolicyRepository youthPolicyRepository;
+    private final ProductsRepository productsRepository;
+
+    // ====== 주거 공고 조회 ======
+    public List<LhNotice> findTopLhByRegionAndKeyword(String region, String keyword, int limit) {
+        String regionLike = "전체".equals(region) ? "" : region;
+        String keywordLike = (keyword == null ? "" : keyword);
+
+        // 키워드가 없으면: 지역 기준 전체 공고 조회
+        if (keywordLike.isBlank()) {
+            return lhNoticeRepository
+                    .findTop5ByCnpCdNmContainingOrderByClsgDtAsc(regionLike);
+        }
+
+        // 키워드가 있으면: 지역 + 공고명으로 필터
+        return lhNoticeRepository
+                .findTop5ByCnpCdNmContainingAndPanNmContainingOrderByClsgDtAsc(
+                        regionLike,
+                        keywordLike
+                );
+    }
+
+    public List<ShAnnouncement> findTopShByRegionAndKeyword(String region, String keyword, int limit) {
+        String regionLike = "전체".equals(region) ? "" : region;
+        String keywordLike = (keyword == null ? "" : keyword);
+
+        // 키워드가 없으면: 지역 기준 전체 공고 조회
+        if (keywordLike.isBlank()) {
+            return shAnnouncementRepository
+                    .findTop5ByRegionContainingOrderByPostDateAsc(regionLike);
+        }
+
+        // 키워드가 있으면: 지역 + 제목으로 필터
+        return shAnnouncementRepository
+                .findTop5ByRegionContainingAndTitleContainingOrderByPostDateAsc(
+                        regionLike,
+                        keywordLike
+                );
+    }
+
+    // ====== 금융 상품 조회 ======
+    public List<Products> findTopFinanceByKeyword(String keyword, int limit) {
+        String keywordLike = (keyword == null || keyword.isBlank()) ? "" : keyword;
+
+        return productsRepository
+                .findTop5ByTypeAndNameContainingIgnoreCaseOrderByIdAsc(
+                        ProductType.FINANCE,
+                        keywordLike
+                );
+    }
+
+    // ====== 청년 정책 조회 ======
+    public List<YouthPolicy> findTopPolicyByKeyword(String keyword, int limit) {
+        String keywordLike = (keyword == null ? "" : keyword);
+
+        return youthPolicyRepository
+                .findTop5ByPolicyNameContainingOrDescriptionContainingOrderByIdAsc(
+                        keywordLike,
+                        keywordLike
+                );
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/DB/DbIntentDetector.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/DB/DbIntentDetector.java
@@ -1,0 +1,72 @@
+package com.example.capstonedesign.domain.chatbot.service.DB;
+
+import com.example.capstonedesign.domain.chatbot.entity.IntentType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DbIntentDetector {
+
+    public IntentType detectIntent(String message) {
+        if (message == null || message.isBlank()) {
+            return IntentType.UNKNOWN;
+        }
+
+        String text = message.toLowerCase();
+
+        // 0단계: 기관 코드(LH/SH)만 입력해도 주거로 인식
+        // 원본 문자열에서 대문자 LH/SH를 우선 체크 (cash 같은 오탐 방지)
+        if (message.contains("LH") || message.contains("엘에이치")
+                || message.contains("SH") || message.contains("에스에이치")) {
+            return IntentType.HOUSING;
+        }
+
+        // 1단계: 지역 이름만 있어도 HOUSING으로 인식
+        if (containsRegionKeyword(message)) {
+            return IntentType.HOUSING;
+        }
+
+        // 주거 관련 키워드
+        if (text.contains("전세") || text.contains("월세")
+                || text.contains("임대") || text.contains("공고")
+                || text.contains("주택") || text.contains("청년주택")) {
+            return IntentType.HOUSING;
+        }
+
+        // 금융 관련 키워드
+        if (text.contains("대출") || text.contains("예금")
+                || text.contains("적금") || text.contains("금리")
+                || text.contains("통장")) {
+            return IntentType.FINANCE;
+        }
+
+        // 정책 관련 키워드
+        if (text.contains("정책") || text.contains("청년정책") || text.contains("지원금")
+                || text.contains("사업") || text.contains("보조금")) {
+            return IntentType.POLICY;
+        }
+
+        // 도움/사용법
+        if (text.contains("사용법") || text.contains("어떻게")
+                || text.contains("도움말") || text.contains("설명")
+                || text.contains("뭐 하는 서비스")) {
+            return IntentType.HELP;
+        }
+
+        return IntentType.UNKNOWN;
+    }
+
+    private boolean containsRegionKeyword(String message) {
+        if (message == null) return false;
+
+        String[] regions = {
+                "서울", "경기", "인천", "부산", "대구",
+                "대전", "광주", "울산", "세종",
+                "강원", "충북", "충남", "전북", "전남",
+                "경북", "경남", "제주"
+        };
+        for (String r : regions) {
+            if (message.contains(r)) return true;
+        }
+        return false;
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/SimpleTextExtractor.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/chatbot/service/SimpleTextExtractor.java
@@ -1,0 +1,77 @@
+package com.example.capstonedesign.domain.chatbot.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SimpleTextExtractor {
+
+    /**
+     * 질문 안에서 지역 이름(서울/경기/인천/부산...)을 간단히 찾아냄
+     * 못 찾으면 "전체" 반환
+     */
+    public String extractRegion(String message) {
+        if (message == null) return "전체";
+
+        if (message.contains("서울")) return "서울";
+        if (message.contains("경기")) return "경기";
+        if (message.contains("인천")) return "인천";
+        if (message.contains("부산")) return "부산";
+        if (message.contains("대구")) return "대구";
+        if (message.contains("대전")) return "대전";
+        if (message.contains("광주")) return "광주";
+        if (message.contains("울산")) return "울산";
+
+        return "전체";
+    }
+
+    /**
+     * 주거 관련 키워드를 간단히 뽑는 예시
+     */
+    public String extractHousingKeyword(String message) {
+        if (message == null) return "";
+
+        if (message.contains("전세")) return "전세";
+        if (message.contains("월세")) return "월세";
+        if (message.contains("청년")) return "청년";
+        if (message.contains("임대")) return "임대";
+
+        return "";
+    }
+
+    /**
+     * 금융 관련 키워드 예시
+     */
+    public String extractFinanceKeyword(String message) {
+        if (message == null) return "";
+
+        if (message.contains("대출")) return "대출";
+        if (message.contains("적금")) return "적금";
+        if (message.contains("예금")) return "예금";
+        if (message.contains("청년")) return "청년";
+
+        return "";
+    }
+
+    public String extractPolicyKeyword(String message) {
+        if (message == null || message.isBlank()) return "";
+
+        String text = message.toLowerCase();
+
+        // 1순위: 구체 키워드
+        if (text.contains("취업")) return "취업";
+        if (text.contains("창업")) return "창업";
+        if (text.contains("교통")) return "교통";
+        if (text.contains("전세") || text.contains("월세") || text.contains("주거")) return "전세";
+
+        // 2순위: "청년 정책" / "청년정책"
+        if (text.contains("청년 정책") || text.contains("청년정책")) return "청년";
+
+        // 3순위: 그냥 "청년"이라도
+        if (text.contains("청년")) return "청년";
+
+        // 4순위: 최소한 "정책"이라도
+        if (text.contains("정책")) return "정책";
+
+        return "";
+    }
+}

--- a/backend/src/main/java/com/example/capstonedesign/domain/housingannouncements/repository/LhNoticeRepository.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/housingannouncements/repository/LhNoticeRepository.java
@@ -56,4 +56,8 @@ public interface LhNoticeRepository extends JpaRepository<LhNotice, Long> {
 
     /** 게시일(panNtStDt) 기준 최신순 상위 20건 조회 */
     List<LhNotice> findTop20ByOrderByPanNtStDtDesc();
+
+    List<LhNotice> findTop5ByCnpCdNmContainingAndPanNmContainingOrderByClsgDtAsc(String regionKeyword, String titleKeyword);
+
+    List<LhNotice> findTop5ByCnpCdNmContainingOrderByClsgDtAsc(String regionLike);
 }

--- a/backend/src/main/java/com/example/capstonedesign/domain/products/repository/ProductsRepository.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/products/repository/ProductsRepository.java
@@ -4,6 +4,7 @@ import com.example.capstonedesign.domain.products.entity.ProductType;
 import com.example.capstonedesign.domain.products.entity.Products;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -37,4 +38,6 @@ public interface ProductsRepository extends JpaRepository<Products, Integer> {
      * WHERE detail_url = ?
      */
     Optional<Products> findByDetailUrl(String detailUrl);
+
+    List<Products> findTop5ByTypeAndNameContainingIgnoreCaseOrderByIdAsc(ProductType productType, String keywordLike);
 }

--- a/backend/src/main/java/com/example/capstonedesign/domain/shannouncements/repository/ShAnnouncementRepository.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/shannouncements/repository/ShAnnouncementRepository.java
@@ -21,4 +21,8 @@ public interface ShAnnouncementRepository extends
 
     /** 게시일(postDate) 기준 최신순 상위 20건 조회 */
     List<ShAnnouncement> findTop20ByOrderByPostDateDesc();
+
+    List<ShAnnouncement> findTop5ByRegionContainingAndTitleContainingOrderByPostDateAsc(String regionKeyword, String keyword);
+
+    List<ShAnnouncement> findTop5ByRegionContainingOrderByPostDateAsc(String regionLike);
 }

--- a/backend/src/main/java/com/example/capstonedesign/domain/users/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/users/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                                 "/api/finance/products/**",
 
                                 // Swagger & 문서 접근 허용
+                                "/api/chat",
                                 "/api/notices/recent",
                                 "/api/housings",
                                 "/api/housings/search",

--- a/backend/src/main/java/com/example/capstonedesign/domain/youthpolicies/repository/YouthPolicyRepository.java
+++ b/backend/src/main/java/com/example/capstonedesign/domain/youthpolicies/repository/YouthPolicyRepository.java
@@ -36,4 +36,6 @@ public interface YouthPolicyRepository extends JpaRepository<YouthPolicy, Long> 
         ORDER BY y.startDate DESC
     """)
     List<YouthPolicy> findActiveOrderByStartDateDesc(@Param("today") String today, Pageable pageable);
+
+    List<YouthPolicy> findTop5ByPolicyNameContainingOrDescriptionContainingOrderByIdAsc(String keywordLike, String keywordLike1);
 }

--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from "react";
+import FloatingChatbot from "./FloatingChatbot";
 
 export default function AppLayout({ children, narrow = false }) {
   const [activeDropdown, setActiveDropdown] = useState(null);
@@ -203,6 +204,9 @@ export default function AppLayout({ children, narrow = false }) {
       >
         {children}
       </main>
+
+        {/* 플로팅 챗봇 */}
+        <FloatingChatbot />
 
       {/* 공통 푸터 */}
       <footer style={styles.footer}>© 2025 Y-Nest</footer>

--- a/frontend/src/components/ChatWidget.jsx
+++ b/frontend/src/components/ChatWidget.jsx
@@ -1,0 +1,312 @@
+import { useEffect, useRef, useState } from "react";
+import api from "../lib/axios";
+
+/**
+ * props:
+ * - variant: "embedded" | "floating"
+ * - onClose?: () => void   // floating일 때 X 버튼용
+ */
+export default function ChatWidget({ variant = "embedded", onClose }) {
+    const [messages, setMessages] = useState([
+        {
+            from: "bot",
+            text: "안녕하세요! Y-Nest 챗봇 네스티예요. 🕊️\n주거, 금융, 청년정책에 대해 궁금한 걸 편하게 물어봐 주세요.",
+        },
+    ]);
+    const [input, setInput] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState("");
+    const scrollRef = useRef(null);
+
+    const isFloating = variant === "floating";
+
+    // 추천 질문 목록
+    const suggestions = [
+        "서울 전세 지원 뭐 있어?",
+        "청년 적금 상품 추천해 줘",
+        "청년 정책 알려 줘",
+        "LH 전세임대 공고 알려 줘",
+    ];
+
+    // 새로운 메시지 추가될 때 자동 스크롤
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [messages]);
+
+    const handleChange = (e) => {
+        setInput(e.target.value);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === "Enter" && e.shiftKey) return; // 줄바꿈
+        if (e.key === "Enter") {
+            e.preventDefault();
+            handleSend();
+        }
+    };
+
+    // 실제 전송 로직을 공통 함수로 분리
+    const sendMessage = async (rawText) => {
+        const trimmed = rawText.trim();
+        if (!trimmed || isLoading) return;
+
+        setIsLoading(true);
+        setError("");
+
+        const userMessage = { from: "user", text: trimmed };
+        setMessages((prev) => [...prev, userMessage]);
+        setInput("");
+
+        try {
+            const res = await api.post("/api/chat", { message: trimmed });
+            const botReply = res?.data?.reply ?? "응답을 받아오지 못했어요. 😢";
+
+            const botMessage = { from: "bot", text: botReply };
+            setMessages((prev) => [...prev, botMessage]);
+        } catch (err) {
+            console.error(err);
+            setError("챗봇 서버와 통신 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요. 😢");
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleSend = () => {
+        sendMessage(input);
+    };
+
+    const handleSuggestionClick = (text) => {
+        if (isLoading) return;
+        sendMessage(text);
+    };
+
+    const containerStyle = isFloating
+        ? { ...styles.container, ...styles.floatingContainer }
+        : styles.container;
+
+    return (
+        <div style={containerStyle}>
+            <div style={styles.header}>
+                <div style={styles.headerLeft}>
+                    <span style={styles.headerTitle}>Y-Nest 챗봇 네스티</span>
+                    <span style={styles.headerSubtitle}>DB 기반 검색 도우미</span>
+                </div>
+                {isFloating && (
+                    <button style={styles.closeButton} onClick={onClose}>
+                        ×
+                    </button>
+                )}
+            </div>
+
+            {/* 추천 질문 버튼 영역 */}
+            <div style={styles.suggestionBar}>
+                {suggestions.map((s, idx) => (
+                    <button
+                        key={idx}
+                        style={styles.suggestionButton}
+                        onClick={() => handleSuggestionClick(s)}
+                        disabled={isLoading}
+                    >
+                        {s}
+                    </button>
+                ))}
+            </div>
+
+            <div style={styles.messageList} ref={scrollRef}>
+                {messages.map((msg, idx) => (
+                    <div
+                        key={idx}
+                        style={{
+                            ...styles.messageRow,
+                            justifyContent: msg.from === "user" ? "flex-end" : "flex-start",
+                        }}
+                    >
+                        <div
+                            style={{
+                                ...styles.bubble,
+                                ...(msg.from === "user" ? styles.userBubble : styles.botBubble),
+                            }}
+                        >
+                            {msg.text}
+                        </div>
+                    </div>
+                ))}
+                {isLoading && (
+                    <div style={styles.messageRow}>
+                        <div style={{ ...styles.bubble, ...styles.botBubble }}>
+                            답변을 준비하고 있어요... ⏳
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {error && <div style={styles.error}>{error}</div>}
+
+            <div style={styles.inputArea}>
+        <textarea
+            style={styles.textarea}
+            placeholder="예) 서울 전세 지원 뭐 있는지 알려 줘"
+            value={input}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            rows={2}
+        />
+                <button
+                    style={{
+                        ...styles.sendButton,
+                        ...(isLoading || !input.trim() ? styles.sendButtonDisabled : {}),
+                    }}
+                    onClick={handleSend}
+                    disabled={isLoading || !input.trim()}
+                >
+                    전송
+                </button>
+            </div>
+        </div>
+    );
+}
+
+const styles = {
+    container: {
+        position: "relative",
+        width: "100%",
+        maxWidth: "720px",
+        margin: "24px auto 0",
+        borderRadius: "16px",
+        border: "1px solid #e0e0e0",
+        backgroundColor: "#ffffff",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.04)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+    },
+    floatingContainer: {
+        position: "fixed",
+        right: "24px",
+        bottom: "88px",
+        maxWidth: "600px",   // 360 → 420
+        width: "520px",      // 360 → 420
+        maxHeight: "580px",  // 520 → 600
+        height: "600px",
+        zIndex: 9999,
+    },
+    header: {
+        padding: "10px 14px",
+        borderBottom: "1px solid #f0f0f0",
+        background:
+            "linear-gradient(90deg, #3f51b5 0%, #5c6bc0 50%, #7986cb 100%)",
+        color: "#ffffff",
+        display: "flex",
+        alignItems: "center",
+    },
+    headerLeft: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "2px",
+        flex: 1,
+    },
+    headerTitle: {
+        fontSize: "18px",
+        fontWeight: 700,
+    },
+    headerSubtitle: {
+        fontSize: "14px",
+        opacity: 0.9,
+    },
+    closeButton: {
+        border: "none",
+        background: "transparent",
+        color: "#ffffff",
+        fontSize: "30px",
+        cursor: "pointer",
+        padding: 0,
+        marginLeft: "8px",
+    },
+    suggestionBar: {
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "6px",
+        padding: "8px 10px",
+        borderBottom: "1px solid #f0f0f0",
+        backgroundColor: "#fafbff",
+    },
+    suggestionButton: {
+        fontSize: "14px",
+        padding: "4px 8px",
+        borderRadius: "999px",
+        border: "1px solid #d0d4ff",
+        backgroundColor: "#ffffff",
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+    },
+    messageList: {
+        padding: "10px 10px 8px",
+        flex: 1,
+        overflowY: "auto",
+        backgroundColor: "#fafafa",
+    },
+    messageRow: {
+        display: "flex",
+        marginBottom: "6px",
+    },
+    bubble: {
+        maxWidth: "80%",
+        padding: "8px 10px",
+        borderRadius: "12px",
+        fontSize: "16px",
+        lineHeight: 1.4,
+        whiteSpace: "pre-wrap",
+    },
+    userBubble: {
+        backgroundColor: "#3f51b5",
+        color: "#ffffff",
+        borderBottomRightRadius: "2px",
+    },
+    botBubble: {
+        backgroundColor: "#ffffff",
+        color: "#333333",
+        border: "1px solid #e0e0e0",
+        borderBottomLeftRadius: "2px",
+    },
+    inputArea: {
+        borderTop: "1px solid #f0f0f0",
+        padding: "8px",
+        display: "flex",
+        gap: "8px",
+        alignItems: "flex-end",
+        backgroundColor: "#ffffff",
+    },
+    textarea: {
+        flex: 1,
+        resize: "none",
+        borderRadius: "8px",
+        border: "1px solid #d0d0d0",
+        padding: "8px",
+        fontSize: "15px",
+        fontFamily: "inherit",
+        outline: "none",
+    },
+    sendButton: {
+        minWidth: "68px",
+        height: "36px",
+        borderRadius: "8px",
+        border: "none",
+        backgroundColor: "#3f51b5",
+        color: "#ffffff",
+        fontSize: "13px",
+        fontWeight: 600,
+        cursor: "pointer",
+        padding: "0 12px",
+    },
+    sendButtonDisabled: {
+        opacity: 0.5,
+        cursor: "default",
+    },
+    error: {
+        padding: "4px 10px 0",
+        fontSize: "12px",
+        color: "#d32f2f",
+    },
+};

--- a/frontend/src/components/FloatingChatbot.jsx
+++ b/frontend/src/components/FloatingChatbot.jsx
@@ -1,0 +1,45 @@
+import {useState} from "react";
+import ChatWidget from "./ChatWidget";
+
+export default function FloatingChatbot() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggle = () => setIsOpen((prev) => !prev);
+
+    return (
+        <>
+            {/* 플로팅 챗봇 창 */}
+            {isOpen && (
+                <ChatWidget variant="floating" onClose={() => setIsOpen(false)} />
+            )}
+
+            {/* 플로팅 아이콘 버튼 */}
+            <button style={styles.fab} onClick={toggle}>
+                <span style={styles.fabIcon}>💬</span>
+            </button>
+        </>
+    );
+}
+
+const styles = {
+    fab: {
+        position: "fixed",
+        right: "24px",
+        bottom: "24px",
+        width: "57px",
+        height: "57px",
+        borderRadius: "50%",
+        border: "none",
+        backgroundColor: "#6ecd94ff",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        zIndex: 9998,
+    },
+    fabIcon: {
+        fontSize: "24px",
+        color: "#ffffff",
+    },
+};


### PR DESCRIPTION
- chat_messages 엔티티 및 리포지토리 추가
- IntentType + DbIntentDetector 기반 챗봇 서비스 구현
- LH/SH/금융/정책 DB 검색용 DbChatSearchService 추가
- 금융 응답에서 Products 테이블을 사용하도록 수정
- LH/SH 선호 플래그 및 응답 빌더 메서드 분리
- ChatWidget + FloatingChatbot 컴포넌트 추가 및 /api/chat 연동
- 추천 질문 버튼, 자동 스크롤, 줄바꿈, 레이아웃/스타일링 개선